### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-css-files.yml
+++ b/.github/workflows/lint-css-files.yml
@@ -1,4 +1,6 @@
 name: Lint the CSS code style
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/zyang91/engagement-tools-js/security/code-scanning/1](https://github.com/zyang91/engagement-tools-js/security/code-scanning/1)

The best way to fix the problem is to add a `permissions` block limiting the GITHUB_TOKEN used in the workflow to the least privilege required—in this case, only read access to repository contents. This can be done by adding:
```
permissions:
  contents: read
```
at the root level, after the workflow name, so it applies to the entire workflow. No other permissions are needed for the current set of steps. The changes should be made in `.github/workflows/lint-css-files.yml` by inserting the permissions block after the name declaration and before the `on:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
