### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-js-files.yml
+++ b/.github/workflows/lint-js-files.yml
@@ -1,4 +1,6 @@
 name: Lint the JavaScript code style
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/zyang91/engagement-tools-js/security/code-scanning/2](https://github.com/zyang91/engagement-tools-js/security/code-scanning/2)

To fix this problem, we need to configure the job (or the workflow globally) to explicitly restrict the permissions granted to the GitHub Actions `GITHUB_TOKEN`. For workflows that only need to lint code and do not perform push, issue, or PR operations, the permissions can be set to the minimal level required, usually `contents: read`. The best place to set this is either at the root of the workflow (top-level, affecting all jobs), or scoped specifically for the `build` job (if required later for more granularity). In terms of location, the most clear placement is directly below the workflow name.

What is needed:
- In `.github/workflows/lint-js-files.yml`, add a `permissions:` block immediately below the workflow `name:` (line 1 or 2).
- Set `contents: read` as the permissions, which suffices for checking out code.
- No further changes, as this does not affect workflow logic.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
